### PR TITLE
Unified error messages among $play and $repeat

### DIFF
--- a/src/main/java/com/wylxbot/wylx/Commands/Music/PlayCommand.java
+++ b/src/main/java/com/wylxbot/wylx/Commands/Music/PlayCommand.java
@@ -53,7 +53,7 @@ public class PlayCommand extends ServerCommand {
         boolean isSearch;
 
         if (args.length < 2) {
-            displayUsage(event.getChannel());
+            event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
             return;
         }
 
@@ -85,12 +85,12 @@ public class PlayCommand extends ServerCommand {
             if (args.length == 3) {
                 MusicSeek seek = MusicUtils.getDurationFromArg(args[2]);
                 if (seek == null) {
-                    displayUsage(event.getChannel());
+                    event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
                     return;
                 }
                 dur = seek.dur();
             } else if (args.length > 3) {
-                displayUsage(event.getChannel());
+                event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
                 return;
             }
         }
@@ -179,12 +179,5 @@ public class PlayCommand extends ServerCommand {
                     .queue();
         }, List.of(ActionRow.of(components),
                 ActionRow.of(cancelRow)), toSend, null);
-    }
-
-    private void displayUsage(MessageChannelUnion channel) {
-        channel.sendMessage("""
-                Usage:
-                $play <link> <Optional: seconds to skip OR HH:MM:SS>
-                $play <search terms>""").queue();
     }
 }

--- a/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
+++ b/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
@@ -23,7 +23,8 @@ public class RepeatCommand extends ThreadedCommand {
         try{
             x = Integer.parseInt(args[1]);
         } catch(NumberFormatException nfe) {
-            event.getMessage().reply("Unable to turn " + args[1] + " to a number\nUsage $repeat <int x> <str msg>").queue();
+            event.getMessage().reply("Unable to turn " + args[1] + " to a number.\n").queue();
+            event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
             return;
         }
 

--- a/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
+++ b/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
@@ -23,8 +23,7 @@ public class RepeatCommand extends ThreadedCommand {
         try{
             x = Integer.parseInt(args[1]);
         } catch(NumberFormatException nfe) {
-            event.getMessage().reply("Unable to turn " + args[1] + " to a number.\n").queue();
-            event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
+            event.getChannel().sendMessage("Unable to turn " + args[1] + " to a number.\n" + getDescription(ctx.prefix())).queue();
             return;
         }
 


### PR DESCRIPTION
Currently, the `play` command and `repeat` command show error messages that include `$` as a prefix. For all other commands, the `getDescription(ctx.prefix())` function is used and the set prefix is inserted into the message. This pull request brings this standardization over to the `play` and `repeat` commands.